### PR TITLE
Harden password handling

### DIFF
--- a/SFI-V2-master/admin.php
+++ b/SFI-V2-master/admin.php
@@ -121,8 +121,7 @@ $mensaje='';
 								<th onclick="sortTable(2, this)"><p class="text-center">APELLIDO</p></th>
 								<th onclick="sortTable(3, this)"><p class="text-center">DNI</p></th>
 								<th onclick="sortTable(4, this)"><p class="text-center">USUARIO</p></th>
-								<th onclick="sortTable(5, this)"><p class="text-center">CONTACTO</p></th>
-                <th onclick="sortTable(5, this)"><p class="text-center">CONTRASÑA</p></th>
+                                                                <th onclick="sortTable(5, this)"><p class="text-center">CONTACTO</p></th>
 
 							</tr>
 						</thead>
@@ -140,9 +139,7 @@ $mensaje='';
 											<td ><?php echo $ListadoUser[$i]['USER']; ?></td>
 											<td ><?php echo $ListadoUser[$i]['CON_U']; ?></td>
 
-                      <?php if ($_SESSION['Usuario_id_jer'] == 1 ) { ?>
-                <td ><?php echo $ListadoUser[$i]['CONTRA']; ?></td>
-                <?php } ?>
+
 
 									</tr>
 								<?php } ?>

--- a/SFI-V2-master/funciones/AdminPorDNI.php
+++ b/SFI-V2-master/funciones/AdminPorDNI.php
@@ -2,7 +2,7 @@
 function obtenerDatosAdminPorDNI($dni) {
     $conexion = ConexionBD(); 
 
-    $query = "SELECT NOMBRE, APELLIDO, DOMICILIO, CIUDAD, CONTACTO, USUARIO, CONTRASENA FROM usuario WHERE DNI_U = ?";
+    $query = "SELECT NOMBRE, APELLIDO, DOMICILIO, CIUDAD, CONTACTO, USUARIO FROM usuario WHERE DNI_U = ?";
     
     if ($stmt = $conexion->prepare($query)) {
         $stmt->bind_param("s", $dni);

--- a/SFI-V2-master/funciones/UserPorDNI.php
+++ b/SFI-V2-master/funciones/UserPorDNI.php
@@ -2,7 +2,7 @@
 function obtenerDatosUsersPorDNI($dni) {
     $conexion = ConexionBD(); 
 
-    $query = "SELECT NOMBRE, APELLIDO, DOMICILIO, CIUDAD, CONTACTO, USUARIO, CONTRASENA FROM usuario WHERE DNI_U = ?";
+    $query = "SELECT NOMBRE, APELLIDO, DOMICILIO, CIUDAD, CONTACTO, USUARIO FROM usuario WHERE DNI_U = ?";
     
     if ($stmt = $conexion->prepare($query)) {
         $stmt->bind_param("s", $dni);

--- a/SFI-V2-master/funciones/actualizarAdmin.php
+++ b/SFI-V2-master/funciones/actualizarAdmin.php
@@ -9,7 +9,7 @@ function ModificarAdmin($vconexion, $datos) {
     $provincia = $datos['Provincia'];
     $contacto = $datos['ContactoAdmin'];
     $email = $datos['EmailAdmin'];
-    $contra = $datos['ContraAdmin'];
+    $contra = password_hash($datos['ContraAdmin'], PASSWORD_DEFAULT);
     $jer = $datos['Jer'];
 
 $query = "UPDATE usuario SET NOMBRE = ?, APELLIDO = ?, DOMICILIO = ?, CIUDAD = ?, ID_PROV = ?, CONTACTO = ?, USUARIO = ? , CONTRASENA = ?, ID_JER = ?  WHERE DNI_U = ? ";

--- a/SFI-V2-master/funciones/actualizarUser.php
+++ b/SFI-V2-master/funciones/actualizarUser.php
@@ -9,7 +9,7 @@ function ModificarUser($vconexion, $datos) {
     $provincia = $datos['Provincia'];
     $contacto = $datos['ContactoUser'];
     $email = $datos['EmailUser'];
-    $contra = $datos['ContraUser'];
+    $contra = password_hash($datos['ContraUser'], PASSWORD_DEFAULT);
 
 
 $query = "UPDATE usuario SET NOMBRE = ?, APELLIDO = ?, DOMICILIO = ?, CIUDAD = ?, ID_PROV = ?, CONTACTO = ?, USUARIO = ? , CONTRASENA = ? WHERE DNI_U = ? ";

--- a/SFI-V2-master/funciones/insertAdmin.php
+++ b/SFI-V2-master/funciones/insertAdmin.php
@@ -1,16 +1,34 @@
 <?php 
 function InsertarAdmin($vConexion){
-    $Dispo = !empty($_POST['Disponibilidad'])? $_POST['Disponibilidad']:'';
+    $Dispo = !empty($_POST['Disponibilidad']) ? $_POST['Disponibilidad'] : 0;
 
-    $SQL_Insert="INSERT INTO Usuario (DNI_U, ID_JER, ID_PROV, Contrasena, Nombre, Apellido, Usuario, Contacto, Domicilio, Ciudad, Disponibilidad )
-    VALUES (".$_POST['DNIadmin'].",".$_POST['Jerarquia'].",".$_POST['Provincia'].", '".$_POST['PASSadmin']."','".$_POST['NOMadmin']."','".$_POST['APEadmin']."', '".$_POST['EMAILadmin']."',".$_POST['CONTadmin'].", '".$_POST['DOMadmin']."','".$_POST['CIUadmin']."', ".$Dispo." )";
-
-
-
-        if (!mysqli_query($vConexion, $SQL_Insert)) {
-    return false;
+    $sql = "INSERT INTO Usuario (DNI_U, ID_JER, ID_PROV, Contrasena, Nombre, Apellido, Usuario, Contacto, Domicilio, Ciudad, Disponibilidad) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    $stmt = mysqli_prepare($vConexion, $sql);
+    if (!$stmt) {
+        return false;
     }
-    return true;
+
+    $hash = password_hash($_POST['PASSadmin'], PASSWORD_DEFAULT);
+    mysqli_stmt_bind_param(
+        $stmt,
+        "iiisssssssi",
+        $_POST['DNIadmin'],
+        $_POST['Jerarquia'],
+        $_POST['Provincia'],
+        $hash,
+        $_POST['NOMadmin'],
+        $_POST['APEadmin'],
+        $_POST['EMAILadmin'],
+        $_POST['CONTadmin'],
+        $_POST['DOMadmin'],
+        $_POST['CIUadmin'],
+        $Dispo
+    );
+
+    $ok = mysqli_stmt_execute($stmt);
+    mysqli_stmt_close($stmt);
+
+    return $ok;
 }
 
 

--- a/SFI-V2-master/funciones/insertUser.php
+++ b/SFI-V2-master/funciones/insertUser.php
@@ -1,17 +1,34 @@
-<?php 
+<?php
 function InsertarUsuario($vConexion){
-    $valor = !empty($_POST['Numero'])? $_POST['Numero']:'';
-    $Dispo = !empty($_POST['Disponibilidad'])? $_POST['Disponibilidad']:'';
+    $valor = !empty($_POST['Numero']) ? $_POST['Numero'] : 0;
+    $Dispo = !empty($_POST['Disponibilidad']) ? $_POST['Disponibilidad'] : 0;
 
-    $SQL_Insert="INSERT INTO Usuario (DNI_U, ID_JER, ID_PROV, Contrasena, Nombre, Apellido, Usuario, Contacto, Domicilio, Ciudad, Disponibilidad )
-    VALUES (".$_POST['DNI'].",".$valor.",".$_POST['Provincia'].", '".$_POST['ContraUser']."','".$_POST['NombreUser']."','".$_POST['ApellidoUser']."', '".$_POST['EmailUser']."',".$_POST['ContactoUser'].", '".$_POST['DomicilioUser']."','".$_POST['CiudadUser']."',".$Dispo." )";
+    $sql = "INSERT INTO Usuario (DNI_U, ID_JER, ID_PROV, Contrasena, Nombre, Apellido, Usuario, Contacto, Domicilio, Ciudad, Disponibilidad) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    $stmt = mysqli_prepare($vConexion, $sql);
+    if (!$stmt) {
+        return false;
+    }
 
+    $hash = password_hash($_POST['ContraUser'], PASSWORD_DEFAULT);
+    mysqli_stmt_bind_param(
+        $stmt,
+        "iiisssssssi",
+        $_POST['DNI'],
+        $valor,
+        $_POST['Provincia'],
+        $hash,
+        $_POST['NombreUser'],
+        $_POST['ApellidoUser'],
+        $_POST['EmailUser'],
+        $_POST['ContactoUser'],
+        $_POST['DomicilioUser'],
+        $_POST['CiudadUser'],
+        $Dispo
+    );
 
-if (!mysqli_query($vConexion, $SQL_Insert)) {
-    return false;
+    $ok = mysqli_stmt_execute($stmt);
+    mysqli_stmt_close($stmt);
+
+    return $ok;
 }
-return true;
-
-}
-
 ?>

--- a/SFI-V2-master/funciones/login.php
+++ b/SFI-V2-master/funciones/login.php
@@ -1,22 +1,31 @@
 <?php  
 function DatosLogin($vUsuario, $vClave, $vConexion){
-	$Usuario=array();
-	$SQL="SELECT u.DNI_U, u.Disponibilidad, u.Nombre, u.Apellido, j.Jerarquia, u.id_jer
-	FROM usuario u, jerarquia j
-	WHERE Usuario='$vUsuario' AND Contrasena='$vClave' AND u.Id_Jer=j.Id_Jer AND u.disponibilidad=1";
-	$rs = mysqli_query($vConexion, $SQL);
+    $Usuario = array();
+    $sql = "SELECT u.DNI_U, u.Disponibilidad, u.Nombre, u.Apellido, j.Jerarquia, u.id_jer, u.Contrasena
+            FROM usuario u, jerarquia j
+            WHERE u.Usuario = ? AND u.Id_Jer = j.Id_Jer AND u.disponibilidad = 1";
 
-	$data = mysqli_fetch_array($rs);
-	if (!empty($data)){
-		$Usuario['DNI_U'] = $data['DNI_U'];
+    $stmt = mysqli_prepare($vConexion, $sql);
+    if (!$stmt) {
+        return $Usuario;
+    }
+
+    mysqli_stmt_bind_param($stmt, "s", $vUsuario);
+    mysqli_stmt_execute($stmt);
+    $result = mysqli_stmt_get_result($stmt);
+    $data = mysqli_fetch_array($result, MYSQLI_ASSOC);
+
+    if (!empty($data) && password_verify($vClave, $data['Contrasena'])) {
+        $Usuario['DNI_U'] = $data['DNI_U'];
         $Usuario['DISPONIBILIDAD'] = $data['Disponibilidad'];
         $Usuario['NOMBRE'] = $data['Nombre'];
         $Usuario['APELLIDO'] = $data['Apellido'];
         $Usuario['JERARQUIA'] = $data['Jerarquia'];
         $Usuario['IDJER'] = $data['id_jer'];
-        $Usuario['USUARIO'] = $data['Usuario'];
-        }
-        
+        $Usuario['USUARIO'] = $vUsuario;
+    }
+
+    mysqli_stmt_close($stmt);
 
     return $Usuario;
 }

--- a/SFI-V2-master/funciones/mostrarAdmin.php
+++ b/SFI-V2-master/funciones/mostrarAdmin.php
@@ -3,7 +3,7 @@ function ListarAdmin($vConexion) {
 
     $Listado=array();
 
-    $SQL = "SELECT u.nombre, u.apellido, u.DNI_U, u.usuario, u.contacto, u.Disponibilidad, j.jerarquia, u.Contrasena
+    $SQL = "SELECT u.nombre, u.apellido, u.DNI_U, u.usuario, u.contacto, u.Disponibilidad, j.jerarquia
     FROM usuario u, jerarquia j
     WHERE u.id_jer=j.id_jer AND u.id_jer != 2
     ORDER BY u.apellido ASC";
@@ -20,8 +20,7 @@ function ListarAdmin($vConexion) {
             $Listado[$i]['CON_U'] = $data['contacto'];
             $Listado[$i]['DISPO_U'] = $data['Disponibilidad'];
             $Listado[$i]['JERARQUIA'] = $data['jerarquia'];
-            $Listado[$i]['CONTRA'] = $data['Contrasena'];
-
+            
             $i++;
     }
 

--- a/SFI-V2-master/funciones/mostrarUser.php
+++ b/SFI-V2-master/funciones/mostrarUser.php
@@ -3,7 +3,7 @@ function ListarUsuarios($vConexion) {
 
     $Listado=array();
 
-    $SQL = "SELECT u.nombre, u.apellido, u.DNI_U, u.usuario, u.contacto, u.Disponibilidad, u.Contrasena
+    $SQL = "SELECT u.nombre, u.apellido, u.DNI_U, u.usuario, u.contacto, u.Disponibilidad
     FROM usuario u, jerarquia j
     WHERE u.id_jer=j.id_jer AND u.id_jer = 2
     ORDER BY u.apellido ASC";
@@ -19,8 +19,7 @@ function ListarUsuarios($vConexion) {
             $Listado[$i]['USER'] = $data['usuario'];
             $Listado[$i]['CON_U'] = $data['contacto'];
             $Listado[$i]['DISPO_U'] = $data['Disponibilidad'];
-            $Listado[$i]['CONTRA_U'] = $data['Contrasena'];
-
+            
             $i++;
     }
 

--- a/SFI-V2-master/modificarAdmin.php
+++ b/SFI-V2-master/modificarAdmin.php
@@ -223,13 +223,13 @@ if (!empty($mensajeE)) {
 											</div>
 									    </div>
 
-									    <div class="mdl-cell mdl-cell--6-col mdl-cell--8-col-tablet">
-											<div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-												<input class="mdl-textfield__input" type="text" id="ContraAdmin" name="ContraAdmin" value="<?php echo htmlspecialchars($contra); ?>">
-												<label class="mdl-textfield__label" >Contraseña</label>
-												<span class="mdl-textfield__error">Contraseña invalida</span>
-											</div>
-									    </div>
+                                                                            <div class="mdl-cell mdl-cell--6-col mdl-cell--8-col-tablet">
+                                                                               <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                                                                               <input class="mdl-textfield__input" type="password" id="ContraAdmin" name="ContraAdmin" value="">
+                                                                               <label class="mdl-textfield__label" >Contraseña</label>
+                                                                               <span class="mdl-textfield__error">Contraseña invalida</span>
+                                                                               </div>
+                                                                            </div>
 
 
 

--- a/SFI-V2-master/modificarUser.php
+++ b/SFI-V2-master/modificarUser.php
@@ -221,13 +221,13 @@ if (!empty($mensajeE)) {
 											</div>
 									    </div>
 
-									    <div class="mdl-cell mdl-cell--6-col mdl-cell--8-col-tablet">
-											<div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-												<input class="mdl-textfield__input" type="text" id="ContraUser" name="ContraUser" value="<?php echo htmlspecialchars($contra); ?>">
-												<label class="mdl-textfield__label" >Contraseña</label>
-												<span class="mdl-textfield__error">Contraseña invalida</span>
-											</div>
-									    </div>
+                                                                            <div class="mdl-cell mdl-cell--6-col mdl-cell--8-col-tablet">
+                                                                               <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                                                                               <input class="mdl-textfield__input" type="password" id="ContraUser" name="ContraUser" value="">
+                                                                               <label class="mdl-textfield__label" >Contraseña</label>
+                                                                               <span class="mdl-textfield__error">Contraseña invalida</span>
+                                                                               </div>
+                                                                            </div>
 
 									    
  									   <input type="hidden" name="Disponibilidad" value="1">


### PR DESCRIPTION
## Summary
- store passwords securely in `Usuario` table
- verify credentials using password hashes
- use prepared statements for user inserts
- hide password columns from admin views

## Testing
- `php -l` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850e284627c83319999b99de0d05939